### PR TITLE
Entfernung redundante Formulierung

### DIFF
--- a/satzung.typ
+++ b/satzung.typ
@@ -182,9 +182,8 @@
 
 + Der Vorstand besteht aus mindestens drei gleichberechtigten Mitgliedern. Sie
   werden für 2 Jahre gewählt. Wiederwahl ist zulässig. Näheres bestimmt eine von
-  der Mitgliederversammlung zu verabschiedende Wahlordnung. Diese ist von der
-  Mitgliederversammlung zu verabschieden. Der Vorstand bleibt bis zur Wahl eines
-  neuen Vorstands im Amt.
+  der Mitgliederversammlung zu verabschiedende Wahlordnung. Der Vorstand bleibt
+  bis zur Wahl eines neuen Vorstands im Amt.
 + Jedes Vorstandsmitglied ist alleinvertretungsberechtigt im Sinne des §26, BGB.
   Gesamtvertretung gilt bei Einstellungen und Entlassungen von Angestellten,
   gerichtlichen Vertretungen und Anzeigen sowie bei Aufnahme von Krediten.


### PR DESCRIPTION
fixes #18

Ursprünglich war diese Änderung in #20, aber der `typstyle --wrap-text` history rewrite (siehe https://github.com/entropia/satzung/pull/20#issuecomment-3174114849) hat den PR leider "kaputt" gemacht.