### PR TITLE
Kassenwart in Beitragsordnung durch Vorstand ersetzen

### DIFF
--- a/vereinsordnungen.typ
+++ b/vereinsordnungen.typ
@@ -10,7 +10,7 @@
 + Verfahren\
   Der Beitrag wird quartalsweise zu Beginn des Quartals erhoben und kann per
   Überweisung entrichtet oder per Lastschriftverfahren eingezogen werden. Es
-  kann auch eine Barzahlung an den Kassenwart erfolgen, sofern dieser zustimmt.
+  kann auch eine Barzahlung an den Vorstand erfolgen, sofern dieser zustimmt.
   Ungeachtet der Kündigung der Mitgliedschaft werden bereits vereinnahmte
   Beiträge nicht erstattet.
 + Nachweis der Ermäßigung\


### PR DESCRIPTION
Seit der MV 2024 TOP 4.1 gibt es den Posten "Kassenwart" nicht mehr. Das
wurde in der Beitragsordnung jedoch nicht angepasst und wird hiermit
nachgeholt.
