### PR TITLE
Aktualisierung Beitragsordnung - Variante 3: Flexibler Mitgliedsbeitrag

### DIFF
--- a/beitragsordnung.typ
+++ b/beitragsordnung.typ
@@ -9,7 +9,7 @@
 + Verfahren\
   Der Beitrag wird quartalsweise zu Beginn des Quartals erhoben und kann per
   Überweisung entrichtet oder per Lastschriftverfahren eingezogen werden. Es
-  kann auch eine Barzahlung an den Kassenwart erfolgen, sofern dieser zustimmt.
+  kann auch eine Barzahlung an den Vorstand erfolgen, sofern dieser zustimmt.
   Ungeachtet der Kündigung der Mitgliedschaft werden bereits vereinnahmte
   Beiträge nicht erstattet.
 + Nachweis der Ermäßigung\

--- a/beitragsordnung.typ
+++ b/beitragsordnung.typ
@@ -1,10 +1,12 @@
 = Beitragsordnung
-+ Höhe des Mitgliedsbeitrags\ Der Mitgliedsbeitrag beträgt:
-  - Für normale Mitglieder 25€ monatlich
-  - Für Mitglieder des CCC e.V. 19€ monatlich
-  - Für Schüler, Studenten, Auszubildende und Menschen mit geringem Einkommen
-    15€ monatlich
-  - Für Fördermitglieder mindestens 6€ monatlich
++ Höhe des Mitgliedsbeitrags\
+  Der Mitgliedsbeitrag wird vom Mitglied festgelegt, beträgt aber mindestens 5€
+  monatlich. Änderungen muss das Mitglied dem Vorstand mindestens einen Monat
+  vor Beginn des nächsten Quartals mitteilen. Rückwirkende Änderungen sind nicht
+  möglich. Empfohlen wird ein Beitrag von:
+  - Für normale Mitglieder mindestens 25€ monatlich
+  - Für Mitglieder des CCC e.V. mindestens 19€ monatlich
+  - Für Schüler, Studenten, und Auszubildende mindestens 15€ monatlich
   - Ehrenmitglieder sind laut Satzung beitragsfrei
 + Verfahren\
   Der Beitrag wird quartalsweise zu Beginn des Quartals erhoben und kann per
@@ -12,9 +14,5 @@
   kann auch eine Barzahlung an den Vorstand erfolgen, sofern dieser zustimmt.
   Ungeachtet der Kündigung der Mitgliedschaft werden bereits vereinnahmte
   Beiträge nicht erstattet.
-+ Nachweis der Ermäßigung\
-  Personen, die den ermäßigten Beitrag in Anspruch nehmen, haben dem Vorstand
-  gegenüber zu erklären, bis zu welchem Datum die Voraussetzungen dafür
-  voraussichtlich gegeben sind. Der Vorstand kann einen Beleg dafür anfordern.
 + Inkrafttreten\
   Diese Beitragsordnung tritt am 01.07.2016 in Kraft.


### PR DESCRIPTION
Es gibt in vielen Fällen Abweichungen von Beitragsordnung. Um das
flexibler zu gestalten wird mit dieser Änderung nur noch ein
Mindestbeitrag festgelegt und aus den vorherigen Beiträgen werden
Empfehlungen.

Seit der MV 2024 TOP 4.1 gibt es den Posten "Kassenwart" nicht mehr. Das
wurde in der Beitragsordnung jedoch nicht angepasst und wird hiermit
nachgeholt.
