### PR TITLE
Anspruch auf Aufwendungserstattung für Mitglieder

### DIFF
--- a/satzung.typ
+++ b/satzung.typ
@@ -119,7 +119,13 @@
 + Die Mitglieder sind verpflichtet, die satzungsgemässen Zwecke des Vereins zu
   unterstützen und zu fördern. Sie sind verpflichtet, die festgesetzten Beiträge
   zu zahlen.
-+ Ordentliche Mitglieder und Ehrenmitglieder haben in der Mitgliedsversammlung
++ Mitglieder haben einen Anspruch auf Ersatz von Aufwendungen, welche ihnen im
+  Rahmen ihrer Tätigkeit für den Verein entstanden sind. Dies gilt jedoch nur,
+  wenn sie dazu vom Vorstand beauftragt wurden. Der Nachweis erfolgt über
+  entsprechende Einzelbelege. Das Nähere regelt eine entsprechende
+  Erstattungsordnung.
++ Ordentliche Mitglieder und Ehrenmitglieder haben in der
+  Mitgliedsversammlung
   das aktive und passive Wahlrecht. Es wird von ihnen erwartet, dass sie an
   Abstimmungen teilnehmen.
 + Fördermitglieder können in der Mitgliederversammlung Anträge stellen und
@@ -144,6 +150,7 @@
   - die Genehmigung der Beitragsordnung,
   - die Genehmigung der Nutzungsordnung,
   - die Genehmigung der Wahlordnung,
+  - die Genehmigung der Erstattungsordnung,
   - die Richtlinie über die Erstattung von Reisekosten und Auslagen,
   - Anträge des Vorstandes und der Mitglieder,
   - die Ernennung von Ehrenmitgliedern,


### PR DESCRIPTION
Fixes #15

Bisher fehlt ein Anspruch für Mitglieder, sich Aufwendungen etwa für Material vom Verein erstatten zu lassen. Dabei ist eine solche Erstattung gelebte Praxis. Die Satzungsänderung soll vor allem diese Praxis abbilden.

Des Weiteren ermöglicht die Satzungsregelung, den Verzicht auf die Erstattung als Spende abzusetzen.

Dabei wird eine enge Fassung gewählt, welche eine Beauftragung durch den Vorstand voraussetzt. Durch den Vorstand und nicht das Plenum, da dieses nicht in der Satzung vorkommt. Die Beauftragung kann in der Praxis wohl als implizit vorhanden behandelt werden.

Eine Regelung für den Vorstand ist nicht notwendig, da diesem bereits über §§ 670, 27 Abs. 3 S. 1 BGB ein Erstattungsanspruch zukommt.

Eine mögliche nähere Regelung könnte eine beispielhafte Auflistung von Aufwendungen umfassen, welche durch den Verein zu ersetzen sind, etwa Material- oder Fahrtkosten.