### PR TITLE
Entferne Redundante Formulierung aus §1 Name…

### DIFF
--- a/satzung.typ
+++ b/satzung.typ
@@ -10,11 +10,9 @@
 
 == Name, Eintragung, Sitz, Geschäftsjahr
 
-+ Der Verein trägt den Namen „Entropia“. Der Verein soll in das Vereinsregister
-  eingetragen werden. Nach der Eintragung führt er den Zusatz „e.V.“.
++ Der Verein trägt den Namen „Entropia e.V.“.
 + Der Verein hat seinen Sitz in Karlsruhe. Das Geschäftsjahr des Vereins ist das
-  Kalenderjahr. Das erste Geschäftsjahr beginnt mit dem Tag der Gründung und
-  endet am 31.12.1999.
+  Kalenderjahr.
 
 == Vereinszweck
 


### PR DESCRIPTION
Der Verein is mitlerweile im Vereinsregister eingetragen. Damit muss er nicht mehr warten den Zusatz e.V. zu tragen.

Dass das Kalenderjahr das Geschäftsjahr ist, ist eine ausreichende Regelung. 1999 ist schon vorbei.