### PR TITLE
Klare Regelungen zum ablehnen einer Mitgliedschaft

### DIFF
--- a/satzung.typ
+++ b/satzung.typ
@@ -64,10 +64,11 @@
 == Erwerb der Mitgliedschaft
 
 + Die Gründer sind Mitglieder des Vereins. Über die Aufnahme weiterer Mitglieder
-  entscheidet der Vorstand.
+  entscheidet der Vorstand und kann diese ohne Begründung ablehnen.
 + Der Beitrittsantrag erfolgt in Textform gegenüber dem Vorstand. Über die
   Annahme des Beitrittsantrages entscheidet der Vorstand. Die Mitgliedschaft
   beginnt mit der Annahme des Beitrittsantrages.
++ Ein Anspruch auf Aufnahme besteht nicht.
 
 == Verlust der Mitgliedschaft
 


### PR DESCRIPTION
In unserer Satzung ist das ablehnen einerMitgliedschaft leider noch nicht geregelt. Damit macht man sich iirc angreifbar gegenüber Personen, die sich auf teufel komm raus in den Verein reinklagen wollen. Um da von vorne herein dagegen zu wirken, sollten wir die Ablehnung in der Satzung klar Regeln.

Hier wäre nun eine Regelung, die es dem Vorstand recht einfach macht Leute nicht aufzunehmen, denn "Ein Anspruch auf Aufnahme besteht nicht.".

Das könnte man natürlich auch anders regeln. Zum Beispiel in dem wir das verfahren einer Ablehnung genau Aufzeigen. Zum Beispiel in dem wir festlegen das man nach Ablehnung innerhalb von 1 Monat in schriftform wiedersprechen muss und die Aufnahme dann durch die MV neu entscheiden wird.