### PR TITLE
gruppenbezogen menschenfeindlich als Grund zum Ausschluss

### DIFF
--- a/satzung.typ
+++ b/satzung.typ
@@ -80,14 +80,17 @@
   einer Kündigungsfrist von einem Monat zulässig.
 + Ein Mitglied kann durch Beschluss des Vorstandes ausgeschlossen werden, wenn
   es das Ansehen des Vereins schädigt, in schwerwiegender Weise gegen diese
-  Satzung oder gegen eine Vereinsordnung verstößt oder ein sonstiger wichtiger
-  Grund vorliegt.\
-  Das Mitglied ist vor einem derartigen Ausschluss vom Vorstand zu hören. Ein
-  Mitglied kann ferner durch Beschluss des Vorstandes ausgeschlossen werden,
-  wenn es trotz zweimaliger Mahnung mit der Zahlung von mindestens zwei
-  Vereinsbeiträgen im Rückstand ist. Der Ausschlussbeschluss darf erst
-  bekanntgegeben werden, wenn seit der Absendung der zweiten Mahnung mindestens
-  drei Monate vergangen sind, ohne dass die Beitragsrückstände beglichen wurden.
+  Satzung oder gegen eine Vereinsordnung verstößt, sich innerhalb des Vereins
+  wiederholt respektlos oder beleidigend äußert, sich gruppenbezogen
+  menschenfeindlich betätigt, seinen Beitragsverpflichtungen nicht nachkommt
+  oder wenn ein sonstiger wichtiger Grund vorliegt. Der Vorstand muss dem
+  auszuschließenden Mitglied den Beschluss in Textform unter Angabe von Gründen
+  mitteilen und ihm auf Verlangen eine Anhörung gewähren. Ein Mitglied kann
+  ferner durch Beschluss des Vorstandes ausgeschlossen werden, wenn es trotz
+  zweimaliger Mahnung mit der Zahlung von mindestens zwei Vereinsbeiträgen im
+  Rückstand ist. Der Ausschlussbeschluss darf erst bekanntgegeben werden, wenn
+  seit der Absendung der zweiten Mahnung mindestens drei Monate vergangen sind,
+  ohne dass die Beitragsrückstände beglichen wurden.
 + Gegen den Beschluss des Vorstandes ist die Anrufung der Mitgliederversammlung
   zulässig. Die Anrufung muss innerhalb einer Frist von vier Wochen ab Zugang
   des Ausschließungsbeschlusses schriftlich beim Vorstand eingelegt werden. Bis


### PR DESCRIPTION
Unsere Satzung oder des Grundgesetz hat leider nicht alle Werte, die wir im Chaos wichtig finden, verinnerlicht. Daher schlage ich vor Formulierungen wie "gruppenbezogen menschenfeindlich" und ähnliche als Ausschlussgrund mit in die Satzung zu schreiben. Dies ist Inspiriert an der Satzung des hackwerk Aalen e.V. – https://aalen.space/