### PR TITLE
Mitgliedsbeiträge stunden, ermäßigen und erlassen

### DIFF
--- a/satzung.typ
+++ b/satzung.typ
@@ -103,6 +103,7 @@
 + Im begründeten Einzelfall kann für ein Mitglied durch Vorstandsbeschluss
   ein(e) von der Beitragsordnung abweichende(r) Beitrag und Beitragszahlung
   festgesetzt werden.
++ Der Vorstand kann Mitgliedsbeiträge stunden, ermäßigen und erlassen.
 + Bei Beendigung der Mitgliedschaft verfällt der für das laufende Jahr gezahlte
   Beitrag. Es besteht kein Anspruch auf Rückerstattung.
 + Ehrenmitglieder sind von Beitragsleistungen befreit.


### PR DESCRIPTION
Unabhängig von der Neuregelung des Mitgliedsbeitrag,  wäre es ratsam dem Vorstand die ermächtigung zu geben, Mitgliedsbeiträge zu stunden, ermäßigen und zu erlassen. Dies ermöglicht, die Zahlungsfrist eines Beitrags auch rückwirkend zu ändern und triggert so im härtefall keinen ungewünschten Vreinsausschluss oder unklarheiten darüber, ob das nun zulässig war oder nicht.