### PR TITLE
Mitgliederbefragung streichen

### DIFF
--- a/satzung.typ
+++ b/satzung.typ
@@ -266,12 +266,6 @@ festgelegt. Nutzungsentgelte, Schutzgebühren u.a. regelt der Vorstand.
 + Eine Abschrift dieser Niederschrift wird den Mitgliedern in Textform
   zugesandt.
 
-== Mitgliederbefragung
-
-Der Vorstand kann in wichtigen Fragen eine elektronische oder nichtelektronische
-Mitgliederbefragung durchführen. Eine solche Befragung ist auch auf Antrag eines
-Drittels der Mitglieder durchzuführen.
-
 == Auflösung
 
 + Bei Auflösung des Vereins oder bei Wegfall steuerbegünstigter Zwecke fällt das


### PR DESCRIPTION
Ich finde den Passus mit der Mitgliederbefragung sehr merkwürdig.

Entweder wir verschärfen den stark. Dann sollten wir aber auch mal regeln, was mit den Ergebnissen der Befragung passieren soll. Die Hürde von 1/3 für nicht-vorstände senken. Und eventuell die Mitglieder zur Antwort verpflichten.

Oder wir streichen das ganze.