### PR TITLE
Reformat with typstyle 0.13.18

### DIFF
--- a/wahlordnung.typ
+++ b/wahlordnung.typ
@@ -43,7 +43,7 @@ Beschlussfassung durch die ordentliche Mitgliederversammlung am 21.09.2025.
   Mehrheit erreicht ist der Posten oder Block unbesetzt; es erfolgt ein neuer
   Wahlgang, gegebenenfalls mit neuen Vorschlägen.
 + Wenn mehrere Kandidat*innen oder Listen zur Wahl stehen, wird per *absoluter
-    Mehrheitswahl* gewählt. Gewählt wird in gemeinsamen Wahlgängen für alle
+  Mehrheitswahl* gewählt. Gewählt wird in gemeinsamen Wahlgängen für alle
   Posten. Stimmberechtigte Mitglieder stimmen für so viele Posten wie zu
   vergeben sind, wobei zu berücksichtigen ist wie lang Listen sind. Listen oder
   Kandidat*innen die eine absolute Mehrheit erhalten sind gewählt. Sollten nicht


### PR DESCRIPTION
See CI failure in https://github.com/entropia/satzung/actions/runs/18532445686. Seems to be caused by https://github.com/typstyle-rs/typstyle/commit/8b6d1792dccd107f31c1d5bc6cf783f5370182ee, which is a breaking change released in a patch version... :|
